### PR TITLE
Fix zephyr builds

### DIFF
--- a/src/zephyr/arch/arm/cortex_m/arch_util.c
+++ b/src/zephyr/arch/arm/cortex_m/arch_util.c
@@ -1,4 +1,4 @@
-#include <arch/arm/aarch32/cortex_m/cmsis.h>
+#include <zephyr/arch/arm/aarch32/cortex_m/cmsis.h>
 
 #include "bench_api.h"
 #include "bench_utils.h"

--- a/src/zephyr/arch/riscv/core/arch_util.c
+++ b/src/zephyr/arch/riscv/core/arch_util.c
@@ -2,17 +2,18 @@
 #include "bench_utils.h"
 
 extern struct _isr_table_entry _sw_isr_table[];
+extern uint32_t riscv_machine_timer_irq;
 
 bench_isr_handler_t bench_timer_isr_get(void)
 {
 
 	/*
 	 * At the current time, it is assumed that the timer interrupt
-	 * is NOT a level 2 interrupt and RISCV_MACHINE_TIMER_IRQ can
+	 * is NOT a level 2 interrupt and riscv_machine_timer_irq can
 	 * simply be an index into _sw_isr_table[].
 	 */
 
-	return (bench_isr_handler_t)_sw_isr_table[RISCV_MACHINE_TIMER_IRQ].isr;
+	return (bench_isr_handler_t)_sw_isr_table[riscv_machine_timer_irq].isr;
 }
 
 uint32_t bench_timer_cycles_per_second(void)
@@ -33,7 +34,7 @@ uint32_t bench_timer_cycles_per_tick(void)
 
 void bench_timer_isr_set(bench_isr_handler_t  isr)
 {
-	_sw_isr_table[RISCV_MACHINE_TIMER_IRQ].isr = (void(*)(const void *))isr;
+	_sw_isr_table[riscv_machine_timer_irq].isr = (void(*)(const void *))isr;
 
 	return;
 }

--- a/src/zephyr/bench_porting_layer_zephyr.c
+++ b/src/zephyr/bench_porting_layer_zephyr.c
@@ -2,9 +2,9 @@
 
 #include "bench_api.h"
 #include "bench_porting_layer_zephyr.h"
-#include <zephyr.h>
-#include <timing/timing.h>
-#include <irq_offload.h>
+#include <zephyr/zephyr.h>
+#include <zephyr/timing/timing.h>
+#include <zephyr/irq_offload.h>
 
 /*
  * Constants.

--- a/src/zephyr/bench_porting_layer_zephyr.h
+++ b/src/zephyr/bench_porting_layer_zephyr.h
@@ -3,9 +3,9 @@
 #ifndef PORTING_LAYER_ZEPHYR_H_
 #define PORTING_LAYER_ZEPHYR_H_
 
-#include <zephyr.h>
-#include <kernel.h>
-#include <timing/timing.h>
+#include <zephyr/zephyr.h>
+#include <zephyr/kernel.h>
+#include <zephyr/timing/timing.h>
 #include <stdio.h>
 
 typedef timing_t bench_time_t;

--- a/src/zephyr/timer/bench_cortex_m_systick.c
+++ b/src/zephyr/timer/bench_cortex_m_systick.c
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <arch/arm/aarch32/cortex_m/cmsis.h>
+#include <zephyr/arch/arm/aarch32/cortex_m/cmsis.h>
 
 #include "bench_api.h"
 #include "bench_utils.h"

--- a/src/zephyr/timer/bench_riscv_machine_timer.c
+++ b/src/zephyr/timer/bench_riscv_machine_timer.c
@@ -9,15 +9,54 @@
 
 #define MIN_DELAY  1000ULL
 
+/* neorv32-machine-timer */
+#if DT_HAS_COMPAT_STATUS_OKAY(andestech_machine_timer)
+#define DT_DRV_COMPAT andestech_machine_timer
+
+#define MTIME_REG	DT_INST_REG_ADDR(0)
+#define MTIMECMP_REG	(DT_INST_REG_ADDR(0) + 8)
+#define TIMER_IRQN	DT_INST_IRQN(0)
+/* neorv32-machine-timer */
+#elif DT_HAS_COMPAT_STATUS_OKAY(neorv32_machine_timer)
+#define DT_DRV_COMPAT neorv32_machine_timer
+
+#define MTIME_REG	DT_INST_REG_ADDR(0)
+#define MTIMECMP_REG	(DT_INST_REG_ADDR(0) + 8)
+#define TIMER_IRQN	DT_INST_IRQN(0)
+/* nuclei,systimer */
+#elif DT_HAS_COMPAT_STATUS_OKAY(nuclei_systimer)
+#define DT_DRV_COMPAT nuclei_systimer
+
+#define MTIME_REG	DT_INST_REG_ADDR(0)
+#define MTIMECMP_REG	(DT_INST_REG_ADDR(0) + 8)
+#define TIMER_IRQN	DT_INST_IRQN(0)
+/* sifive,clint0 */
+#elif DT_HAS_COMPAT_STATUS_OKAY(sifive_clint0)
+#define DT_DRV_COMPAT sifive_clint0
+
+#define MTIME_REG	(DT_INST_REG_ADDR(0) + 0xbff8U)
+#define MTIMECMP_REG	(DT_INST_REG_ADDR(0) + 0x4000U)
+#define TIMER_IRQN	DT_INST_IRQ_BY_IDX(0, 1, irq)
+/* telink,machine-timer */
+#elif DT_HAS_COMPAT_STATUS_OKAY(telink_machine_timer)
+#define DT_DRV_COMPAT telink_machine_timer
+
+#define MTIME_REG	DT_INST_REG_ADDR(0)
+#define MTIMECMP_REG	(DT_INST_REG_ADDR(0) + 8)
+#define TIMER_IRQN	DT_INST_IRQN(0)
+#endif
+
+uint32_t riscv_machine_timer_irq = TIMER_IRQN;
+
 /**
  * @brief Read the current cycle count from the MTIME register
  */
 static uint64_t mtime(void)
 {
 #ifdef CONFIG_64BIT
-        return *(volatile uint64_t *)RISCV_MTIME_BASE;
+        return *(volatile uint64_t *)MTIME_REG;
 #else
-        volatile uint32_t *r = (uint32_t *)RISCV_MTIME_BASE;
+        volatile uint32_t *r = (uint32_t *)MTIME_REG;
         uint32_t  lo;
         uint32_t  hi;
 
@@ -32,7 +71,7 @@ static uint64_t mtime(void)
 
 static uint64_t get_hart_mtimecmp(void)
 {
-	return RISCV_MTIMECMP_BASE + (_current_cpu->id * 8);
+	return MTIMECMP_REG + (_current_cpu->id * 8);
 }
 
 /**


### PR DESCRIPTION
Fixes a couple of issues that have resulted from the evolution of the mainline zephyr repo as ...

1. zephyr header files had moved down one sub-directory (include -> include/zephyr)
2. Certain RISC-V macros had been removed and replace by device tree retrieval.

Fixes #2