### PR TITLE
ensure bench_pend_low exit in gather_pend_stats

### DIFF
--- a/src/common/bench_mutex_lock_unlock_test.c
+++ b/src/common/bench_mutex_lock_unlock_test.c
@@ -318,7 +318,7 @@ static void gather_pend_stats(int priority, uint32_t iteration)
 
 	bench_mutex_unlock(MUTEX_ID);
 
-	bench_thread_set_priority(priority + 2);
+	bench_thread_set_priority(priority + 3);
 
 	/* Step 9 */
 


### PR DESCRIPTION
by ensuring the priority of gather_pend_stats lower than bench_pend_low