### PR TITLE
NuttX:new support for NuttX platform

### DIFF
--- a/h/bench_api.h
+++ b/h/bench_api.h
@@ -15,6 +15,9 @@
 #ifdef RTEMS
 #include "../src/rtems/bench_porting_layer_rtems.h"
 #endif
+#ifdef __NuttX__
+#include "../src/nuttx/bench_porting_layer_nuttx.h"
+#endif /* __NuttX__ */
 
 typedef void (*bench_isr_handler_t)(void *arg);
 

--- a/h/bench_utils.h
+++ b/h/bench_utils.h
@@ -20,6 +20,9 @@
 #ifdef RTEMS
 #include "../src/rtems/bench_porting_layer_rtems.h"
 #endif /* RTEMS */
+#ifdef __NuttX__
+#include "../src/nuttx/bench_porting_layer_nuttx.h"
+#endif /* __NuttX__ */
 
 struct bench_stats {
 	bench_time_t avg;

--- a/src/nuttx/bench_porting_layer_nuttx.c
+++ b/src/nuttx/bench_porting_layer_nuttx.c
@@ -1,0 +1,149 @@
+/*
+ * Copyright (c) 2022 Xiaomi Inc.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include "bench_api.h"
+#include <errno.h>
+#include <pthread.h>
+#include <semaphore.h>
+#include <stdlib.h>
+#include <sched.h>
+
+static pthread_t g_bench_threads[CONFIG_RTOS_BENCHMARK_MAXTHREADS];
+static sem_t g_bench_semaphores[CONFIG_RTOS_BENCHMARK_MAXSEMAPHORES];
+static pthread_mutex_t g_bench_mutex[CONFIG_RTOS_BENCHMARK_MAXMUTEXES];
+
+void bench_test_init(void (*test_init_function)(void *))
+{
+	test_init_function(NULL);
+}
+
+static int map_prio(int prio)
+{
+	/* NuttX priorities have smaller numbers with lower priorities
+	 * So we need to remap a small number to a big one, and vice versa
+	 */
+
+	return CONFIG_RTOS_BENCHMARK_PRIORITY + CONFIG_RTOS_BENCHMARK_PRIORITY - prio;
+}
+
+void bench_thread_set_priority(int priority)
+{
+	pthread_setschedprio(0, map_prio(priority));
+}
+
+int bench_thread_create(int thread_id, const char *thread_name, int priority,
+	void (*entry_function)(void *), void *args)
+{
+	return bench_thread_spawn(thread_id, thread_name,
+			priority, entry_function, args);
+}
+
+int bench_thread_spawn(int thread_id, const char *thread_name, int priority,
+	void (*entry_function)(void *), void *args)
+{
+	struct sched_param param;
+	pthread_attr_t attr;
+	int policy;
+	int ret;
+
+	pthread_attr_init(&attr);
+	pthread_getschedparam(0, &policy, &param);
+	param.sched_priority = map_prio(priority);
+	pthread_attr_setschedparam(&attr, &param);
+
+	ret = -pthread_create(&g_bench_threads[thread_id], &attr,
+			(pthread_startroutine_t)entry_function, args);
+	if (ret >= 0) {
+			pthread_setname_np(g_bench_threads[thread_id], thread_name);
+		}
+
+	pthread_attr_destroy(&attr);
+	return ret;
+}
+
+void bench_thread_start(int thread_id)
+{
+}
+
+void bench_thread_resume(int thread_id)
+{
+}
+
+void bench_thread_suspend(int thread_id)
+{
+}
+
+void bench_thread_abort(int thread_id)
+{
+	pthread_cancel(g_bench_threads[thread_id]);
+}
+
+void bench_thread_exit(void)
+{
+	pthread_exit(NULL);
+}
+
+void bench_yield(void)
+{
+	pthread_yield();
+}
+
+int bench_sem_create(int sem_id, int initial_count, int maximum_count)
+{
+	int ret;
+	ret = sem_init(&g_bench_semaphores[sem_id], 0, initial_count);
+	return ret < 0 ? -errno : ret;
+}
+
+void bench_sem_give(int sem_id)
+{
+	sem_post(&g_bench_semaphores[sem_id]);
+}
+
+void bench_sem_give_from_isr(int sem_id)
+{
+	sem_post(&g_bench_semaphores[sem_id]);
+}
+
+int bench_sem_take(int sem_id)
+{
+	int ret;
+	ret = sem_wait(&g_bench_semaphores[sem_id]);
+	return ret < 0 ? -errno : ret;
+}
+
+int bench_mutex_create(int mutex_id)
+{
+	pthread_mutexattr_t attr;
+	int ret;
+
+	pthread_mutexattr_init(&attr);
+	pthread_mutexattr_settype(&attr, PTHREAD_MUTEX_RECURSIVE);
+	ret = -pthread_mutex_init(&g_bench_mutex[mutex_id], &attr);
+	pthread_mutexattr_destroy(&attr);
+
+	return ret;
+}
+
+int bench_mutex_lock(int mutex_id)
+{
+	return -pthread_mutex_lock(&g_bench_mutex[mutex_id]);
+}
+
+int bench_mutex_unlock(int mutex_id)
+{
+	return -pthread_mutex_unlock(&g_bench_mutex[mutex_id]);
+}
+
+void *bench_malloc(size_t size)
+{
+	return malloc(size);
+}
+
+void bench_free(void *ptr)
+{
+	free(ptr);
+}

--- a/src/nuttx/bench_porting_layer_nuttx.h
+++ b/src/nuttx/bench_porting_layer_nuttx.h
@@ -1,0 +1,35 @@
+/*
+ * Copyright (c) 2022 Xiaomi Inc.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef PORTING_LAYER_NUTTX_H_
+#define PORTING_LAYER_NUTTX_H_
+
+#include <nuttx/config.h>
+#include <nuttx/compiler.h>
+#include <stdint.h>
+#include <stdio.h>
+
+#define BENCH_LAST_PRIORITY CONFIG_RTOS_BENCHMARK_PRIORITY
+#define ITERATIONS CONFIG_RTOS_BENCHMARK_ITERATIONS
+#define ARG_UNUSED(x) UNUSED(x)
+#define __weak weak_function
+#define PRINTF(fmt, ...) printf(fmt, ##__VA_ARGS__)
+
+typedef uint64_t bench_time_t;
+typedef void * bench_work;
+
+/*
+ * Not all RTOSes support the same features. To help simplify the common code
+ * as much as possible, where there are known differences in support, various
+ * aspects of the benchmarking can be enabled/disabled as needed.
+ */
+
+#define RTOS_HAS_THREAD_SPAWN         1
+#define RTOS_HAS_THREAD_CREATE_START  0
+#define RTOS_HAS_SUSPEND_RESUME       0
+#define RTOS_HAS_MAIN_ENTRY_POINT     1
+
+#endif /* PORTING_LAYER_NUTTX_H_ */

--- a/src/nuttx/timer/timer.c
+++ b/src/nuttx/timer/timer.c
@@ -1,0 +1,97 @@
+/*
+ * Copyright (c) 2022 Xiaomi Inc.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include "bench_api.h"
+#include <nuttx/arch.h>
+#include <nuttx/clock.h>
+#include <nuttx/wdog.h>
+
+static struct wdog_s g_bench_wdog;
+static wdentry_t g_bench_handler;
+
+void bench_timing_init(void)
+{
+}
+
+void bench_sync_ticks(void)
+{
+}
+
+void bench_timing_start(void)
+{
+}
+
+void bench_timing_stop(void)
+{
+}
+
+bench_time_t bench_timing_counter_get(void)
+{
+	return up_perf_gettime();
+}
+
+bench_time_t bench_timing_cycles_get(bench_time_t *time_start,
+	bench_time_t *time_end)
+{
+	return *time_end - *time_start;
+}
+
+bench_time_t bench_timing_cycles_to_ns(bench_time_t cycles)
+{
+	struct timespec ts;
+	up_perf_convert(cycles, &ts);
+	return (bench_time_t)ts.tv_sec * 1000000000 + ts.tv_nsec;
+}
+
+static void dummy_isr(void *ptr)
+{
+}
+
+bench_isr_handler_t bench_timer_isr_get(void)
+{
+	return dummy_isr;
+}
+
+void bench_timer_isr_set(bench_isr_handler_t handler)
+{
+	g_bench_handler = (wdentry_t)handler;
+}
+
+void bench_timer_isr_restore(bench_isr_handler_t handler)
+{
+	g_bench_handler = (wdentry_t)handler;
+	wd_cancel(&g_bench_wdog);
+}
+
+bench_time_t bench_timer_isr_expiry_set(uint32_t usec)
+{
+	uint32_t ticks = USEC2TICK(usec);
+	uint32_t count = (uint64_t)TICK2USEC(ticks) * up_perf_getfreq() / 1000000;
+
+	wd_start(&g_bench_wdog, ticks, g_bench_handler, 0);
+	return up_perf_gettime() + count;
+}
+
+bench_time_t bench_timer_cycles_diff(bench_time_t trigger,
+	bench_time_t sample)
+{
+	return sample - trigger;
+}
+
+bench_time_t bench_timer_cycles_get(void)
+{
+	return up_perf_gettime();
+}
+
+uint32_t bench_timer_cycles_per_second(void)
+{
+	return up_perf_getfreq();
+}
+
+uint32_t bench_timer_cycles_per_tick(void)
+{
+	return up_perf_getfreq() / TICK_PER_SEC;
+}


### PR DESCRIPTION
NuttX is a real-time operating system (RTOS) with an emphasis on standards compliance and small footprint. Scalable from 8-bit to 64-bit microcontroller environments, the primary governing standards in NuttX are Posix and ANSI standards. Additional standard APIs from Unix and other common RTOS’s (such as VxWorks) are adopted for functionality not available under these standards, or for functionality that is not appropriate for deeply-embedded environments (such as fork()).
NuttX is therefore compliant with the rtosbenchmark test platform
In that change, the following sections were added
- src/nuttx/bench_porting_layer_nuttx.c
- src/nuttx/bench_porting_layer_nuttx.h
- src/nuttx/timer/timer.c
and in
- h/bench_api.
- h/bench_utils.h
into src/nuttx/bench_porting_layer_nuttx.h