### PR TITLE
zephyr: Update include path to cmsis header

### DIFF
--- a/src/zephyr/arch/arm/cortex_m/arch_util.c
+++ b/src/zephyr/arch/arm/cortex_m/arch_util.c
@@ -1,4 +1,4 @@
-#include <zephyr/arch/arm/aarch32/cortex_m/cmsis.h>
+#include <cmsis_core.h>
 
 #include "bench_api.h"
 #include "bench_utils.h"

--- a/src/zephyr/timer/bench_cortex_m_systick.c
+++ b/src/zephyr/timer/bench_cortex_m_systick.c
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <zephyr/arch/arm/aarch32/cortex_m/cmsis.h>
+#include <cmsis_core.h>
 
 #include "bench_api.h"
 #include "bench_utils.h"


### PR DESCRIPTION
Fix a build warning.

The preferred header to include for cmsis is no longer buried deep within the zephyr/arch sub-directories; simply include "cmsis_core.h" instead.

